### PR TITLE
Update package validation baseline to 0.1.0-preview.2.1.0

### DIFF
--- a/src/Pure.Diagram.RichRelationalModel.EFCore.Models.Configurations/Pure.Diagram.RichRelationalModel.EFCore.Models.Configurations.csproj
+++ b/src/Pure.Diagram.RichRelationalModel.EFCore.Models.Configurations/Pure.Diagram.RichRelationalModel.EFCore.Models.Configurations.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.2.0.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.2.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Diagram.RichRelationalModel.EFCore.Models.Configurations</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.2.0.2` to `0.1.0-preview.2.1.0` following the successful publish.